### PR TITLE
Avoid game variants breaking prc3

### DIFF
--- a/PRCS/prc-3.md
+++ b/PRCS/prc-3.md
@@ -82,10 +82,10 @@ sequenceDiagram
     Seller->>Game: Request to mint NFT on <chainId, address>
     Game->>Seller: Unique userTokenId
     destroy Seller
-    Seller->>L1: Mint NFT to chainId <br> using address<br> passing in userTokenId
+    Seller->>L1: Mint NFT to chainId <br> using address<br>
     activate L1
     L1->>Game: Paima Primitive detects NFT creation
-    Game->>Game: check address, chainId and userTokenId match
+    Game->>Game: detects address, chainId and userTokenId match
     L1->>Game: tokenURI
     Game->>L1: Asset state in the game
     Buyer->>L1: Buys NFT on market
@@ -144,6 +144,8 @@ sequenceDiagram
     deactivate Game Contract
 ```
 
+Additionally, apps SHOULD ask the user to sign all transactions first before actually submitting them to the network. This avoid a situation where the user makes a transaction in the game layer, but then rejects (or never signs) the transaction in the base layer (this isn't an invalid state as they can always mint the tx in the base layer later to continue where they left off, but it's poor UX).
+
 There are 2 error-cases to handle:
 1. Querying a `userTokenId` that has not yet been seen by the game node. This should not happen under normal use, but may happen if a user mints more times on the base layer without making any equivalent transaction in the app layer. This should return a `404 error` (to avoid NFT marketplaces caching dummy data)
 2. Querying a `userTokenId` that is marked as invalid for this variation of the game. See [this section](#invalid-mint-response)
@@ -159,7 +161,7 @@ sequenceDiagram
     actor Seller
     participant Game
     destroy Seller
-    Seller->>L1: Mint NFT to chainId <br> using address<br> passing in userTokenId
+    Seller->>L1: Mint NFT to chainId <br> using address
     activate L1
     L1->>Game: Paima Primitive detects NFT creation
     L1->>Game: tokenURI
@@ -219,6 +221,7 @@ Downside:
 - Requires a transaction on the layer where the app is deployed (although usually this is a place where tx fees are cheap) compared to when initiated on the base-layer which does not require an explicit app-layer transaction.
 - Requires extra logic in the Solidity smart contract to avoid double-mints (only 1 address can claim any minted data in the base layer and ensure the address can claim it only once) which increases tx fees.
 - ~175% the gas cost of the base-layer approach (130k ~ 175k gas)
+- Extra work to coordinate submission of transactions on 2 chains at the same time
 
 ### Rationale Base-layer
 

--- a/PRCS/prc-3.md
+++ b/PRCS/prc-3.md
@@ -53,15 +53,16 @@ interface IInverseProjectedNft is IERC4906 {
 We recommend the following baseURI:
 
 ```bash
-https://${rpcBase}/inverseProjection/${purpose}/${chainIdentifier}/
+https://${rpcBase}/inverseProjection/%{standard}/${purpose}/${chainIdentifier}/
 ```
 
 Where
 - `rpcBase` is the URI for the RPC
+- `standard` is for the specific PRC used to define the the format of this endpoint (ex: `prc3`)
 - `purpose` is a app-dependent string to describe what the NFT is for (ex: `monsters`)
 - `chainIdentifier` is a unique ID for the chain following [caip-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
 
-An example of such a `baseURI` is `https://rpc.mygame.com/inverseProjection/monsters/eip155:1/`
+An example of such a `baseURI` is `https://rpc.mygame.com/inverseProjection/prc3/monsters/eip155:1/`
 
 ### Token Identifier
 

--- a/PRCS/prc-3.md
+++ b/PRCS/prc-3.md
@@ -114,6 +114,24 @@ interface IInverseAppProjectedNft is IInverseProjectedNft {
 
 **Note**: the state transition to initiate the inverse projection should *never* fail. If the data received to initiate the projection is invalid, the game should simply mark the data itself as invalid and still increment the user's value for `userTokenId`. This is because even though this inverse projection may be invalid for *this version* of the game, there may be another version of the game run by players where this state transition *is* valid. To make sure all variations of the game have the same value of `userTokenId`, the state transition can never fully be rejected.
 
+```mermaid
+sequenceDiagram
+    actor User
+    participant Game Contract
+    participant Game #35;1
+    participant Game #35;2
+    User->>Game Contract: Initiate inverse projection
+    activate Game Contract
+    Game Contract->>Game #35;1: react to event
+    Game #35;1->>Game #35;1: invalid
+    Note right of Game #35;1: userTokenId +1
+    Game Contract->>Game #35;2: react to event
+    Game #35;2->>Game #35;2: valid
+    Note right of Game #35;2: userTokenId + 1
+    Note right of User: User sees userTokenId + 1<br />in both cases
+    deactivate Game Contract
+```
+
 There are 2 error-cases to handle:
 1. Querying a `userTokenId` that has not yet been seen by the game node. This should not happen under normal use, but may happen if a user mints more times on the base layer without making any equivalent transaction in the app layer. This should return a `404 error` (to avoid NFT marketplaces caching dummy data)
 2. Querying a `userTokenId` that is marked as invalid for this variation of the game. See [this section](#invalid-mint-response)

--- a/PRCS/prc-3.md
+++ b/PRCS/prc-3.md
@@ -112,8 +112,11 @@ interface IInverseAppProjectedNft is IInverseProjectedNft {
 }
 ```
 
-There are 1 error-case to handle:
-1. Querying a `tokenID` that has not yet been seen by the game node. This should not happen under normal use, but may happen if a user mints more times on the base layer without making any equivalent transaction in the app layer. This should return a `404 error` (to avoid NFT marketplaces caching dummy data)
+**Note**: the state transition to initiate the inverse projection should *never* fail. If the data received to initiate the projection is invalid, the game should simply mark the data itself as invalid and still increment the user's value for `userTokenId`. This is because even though this inverse projection may be invalid for *this version* of the game, there may be another version of the game run by players where this state transition *is* valid. To make sure all variations of the game have the same value of `userTokenId`, the state transition can never fully be rejected.
+
+There are 2 error-cases to handle:
+1. Querying a `userTokenId` that has not yet been seen by the game node. This should not happen under normal use, but may happen if a user mints more times on the base layer without making any equivalent transaction in the app layer. This should return a `404 error` (to avoid NFT marketplaces caching dummy data)
+2. Querying a `userTokenId` that is marked as invalid for this variation of the game. See [this section](#invalid-mint-response)
 
 #### 2) Base Layer Initiated
 
@@ -157,7 +160,7 @@ interface IInverseBaseProjectedNft is IInverseProjectedNft {
 
 There are 2 error-cases to handle:
 1. Querying a `tokenID` that has not yet been seen by the game node. This will happen because there is always a delay between something happening on the base layer and the Paima node detecting it. This should return a `404 error` instead of dummy data (to avoid NFT marketplaces caching dummy data)
-2. Invalid `initialData` provided (the definition of invalid is app-specific)
+2. Invalid `initialData` provided (the definition of invalid is app-specific). See [this section](#invalid-mint-response)
 
 #### Invalid mint response
 


### PR DESCRIPTION
I realized that the current PRC3 spec would lead to an issue if multiple variants of a game use the same contract with different state transition rules where the same mint gets different IDs on different variants of the game (see diagram in the markdown for a concrete example)